### PR TITLE
Prevent Exception when trying to auto resolve icon/description when mods were installed manually

### DIFF
--- a/Assets/Scripts/Mods/Mod.cs
+++ b/Assets/Scripts/Mods/Mod.cs
@@ -42,6 +42,9 @@ namespace LethalConfig.Mods
                 parent = Directory.GetParent(searchDir); // This prevents an infinite loop, as parent becomes null if we hit the root of the drive.
             }
 
+            if (searchDir.EndsWith(".dll")) // Return early if the searchDir is a dll file, prevents a crash from occuring below. Commonly occurs when manually installing mods.
+                return;
+
             var iconPath = Directory.EnumerateFiles(searchDir, "icon.png", SearchOption.AllDirectories).FirstOrDefault();
             LoadIcon(iconPath);
 


### PR DESCRIPTION
If a mod is installed right below the plugins dir without a subfolder, it ends up causing the auto resolution to hit an Exception as it's still set to the mod dll file, which is not a directory. This PR makes it so if the searchDir is still a file, it returns early to prevent hitting an Exception.