### PR TITLE
Fixed null exception when lethalconfig can't be injected in the quick menu.

### DIFF
--- a/Assets/Scripts/Patches/MenuManagerPatches.cs
+++ b/Assets/Scripts/Patches/MenuManagerPatches.cs
@@ -32,8 +32,10 @@ namespace LethalConfig.Patches
             LogUtils.LogInfo("Injecting mod config menu into main menu...");
 
             var menuContainer = GameObject.Find("MenuContainer");
-            var mainButtonsTransform = menuContainer.transform.Find("MainButtons");
-            var quitButton = mainButtonsTransform.Find("QuitButton").gameObject;
+            var mainButtonsTransform = menuContainer?.transform.Find("MainButtons");
+            var quitButton = mainButtonsTransform?.Find("QuitButton")?.gameObject;
+
+            if (menuContainer == null || mainButtonsTransform == null || quitButton == null) return;
 
             MenusUtils.InjectMenu(menuContainer.transform, mainButtonsTransform, quitButton);
         }

--- a/Assets/Scripts/Patches/QuickMenuManagerPatches.cs
+++ b/Assets/Scripts/Patches/QuickMenuManagerPatches.cs
@@ -25,8 +25,10 @@ namespace LethalConfig.Patches
         {
             LogUtils.LogInfo("Injecting mod config menu into quick menu...");
             var quickMenu = __instance.menuContainer;
-            var mainButtonsTransform = quickMenu.transform.Find("MainButtons");
-            var quitButton = mainButtonsTransform.Find("Quit").gameObject;
+            var mainButtonsTransform = quickMenu?.transform.Find("MainButtons");
+            var quitButton = mainButtonsTransform?.Find("Quit").gameObject;
+
+            if (quickMenu == null || mainButtonsTransform == null || quitButton == null) return;
 
             MenusUtils.InjectMenu(quickMenu.transform, mainButtonsTransform, quitButton);
         }

--- a/Assets/Scripts/Patches/QuickMenuManagerPatches.cs
+++ b/Assets/Scripts/Patches/QuickMenuManagerPatches.cs
@@ -15,8 +15,8 @@ namespace LethalConfig.Patches
         {
             var configMenu = __instance.menuContainer.transform.GetComponentInChildren<ConfigMenu>(true);
             var notification = __instance.menuContainer.transform.GetComponentInChildren<ConfigMenuNotification>(true);
-            configMenu.Close(false);
-            notification.Close(false);
+            configMenu?.Close(false);
+            notification?.Close(false);
         }
 
         [HarmonyPatch("Start")]


### PR DESCRIPTION
Prevents error mentioned in #11 from happening, allowing the "Resume" button and escape button to work.
Does not fix the failure to inject the LethalConfig button.