### PR TITLE
Reading Min/Max values from AcceptableValueRange when not set in options

### DIFF
--- a/Assets/Scripts/ConfigItems/FloatInputFieldConfigItem.cs
+++ b/Assets/Scripts/ConfigItems/FloatInputFieldConfigItem.cs
@@ -14,8 +14,10 @@ namespace LethalConfig.ConfigItems
         public FloatInputFieldConfigItem(ConfigEntry<float> configEntry, bool requiresRestart) : this(configEntry, GetDefaultOptions(configEntry, requiresRestart)) { }
         public FloatInputFieldConfigItem(ConfigEntry<float> configEntry, FloatInputFieldOptions options) : base(configEntry, options)
         {
-            MinValue = options.Min;
-            MaxValue = options.Max;
+            var acceptableValues = configEntry.Description.AcceptableValues;
+
+            MinValue = options.Min ?? (acceptableValues as AcceptableValueRange<float>)?.MinValue ?? float.MinValue;
+            MaxValue = options.Max ?? (acceptableValues as AcceptableValueRange<float>)?.MaxValue ?? float.MaxValue;
         }
 
         internal override GameObject CreateGameObjectForConfig()

--- a/Assets/Scripts/ConfigItems/FloatSliderConfigItem.cs
+++ b/Assets/Scripts/ConfigItems/FloatSliderConfigItem.cs
@@ -14,8 +14,10 @@ namespace LethalConfig.ConfigItems
         public FloatSliderConfigItem(ConfigEntry<float> configEntry, bool requiresRestart) : this(configEntry, GetDefaultOptions(configEntry, requiresRestart)) { }
         public FloatSliderConfigItem(ConfigEntry<float> configEntry, FloatSliderOptions options) : base(configEntry, options)
         {
-            MinValue = options.Min;
-            MaxValue = options.Max;
+            var acceptableValues = configEntry.Description.AcceptableValues;
+
+            MinValue = options.Min ?? (acceptableValues as AcceptableValueRange<float>)?.MinValue ?? 0;
+            MaxValue = options.Max ?? (acceptableValues as AcceptableValueRange<float>)?.MaxValue ?? 1;
         }
 
         internal override GameObject CreateGameObjectForConfig()
@@ -30,7 +32,7 @@ namespace LethalConfig.ConfigItems
             return new()
             {
                 Min = (acceptableValues as AcceptableValueRange<float>)?.MinValue ?? 0,
-                Max = (acceptableValues as AcceptableValueRange<float>)?.MaxValue ?? 100,
+                Max = (acceptableValues as AcceptableValueRange<float>)?.MaxValue ?? 1,
                 RequiresRestart = requiresRestart
             };
         }

--- a/Assets/Scripts/ConfigItems/FloatStepSliderConfigItem.cs
+++ b/Assets/Scripts/ConfigItems/FloatStepSliderConfigItem.cs
@@ -17,8 +17,8 @@ namespace LethalConfig.ConfigItems
         {
             var acceptableValues = configEntry.Description.AcceptableValues;
 
-            MinValue = options.Min;
-            MaxValue = options.Max;
+            MinValue = options.Min ?? (acceptableValues as AcceptableValueRange<float>)?.MinValue ?? 0;
+            MaxValue = options.Max ?? (acceptableValues as AcceptableValueRange<float>)?.MaxValue ?? 1;
             Step = options.Step;
         }
 
@@ -34,7 +34,7 @@ namespace LethalConfig.ConfigItems
             return new()
             {
                 Min = (acceptableValues as AcceptableValueRange<float>)?.MinValue ?? 0,
-                Max = (acceptableValues as AcceptableValueRange<float>)?.MaxValue ?? 100,
+                Max = (acceptableValues as AcceptableValueRange<float>)?.MaxValue ?? 1,
                 Step = 0.1f,
                 RequiresRestart = requiresRestart
             };

--- a/Assets/Scripts/ConfigItems/IntInputFieldConfigItem.cs
+++ b/Assets/Scripts/ConfigItems/IntInputFieldConfigItem.cs
@@ -14,8 +14,10 @@ namespace LethalConfig.ConfigItems
         public IntInputFieldConfigItem(ConfigEntry<int> configEntry, bool requiresRestart) : this(configEntry, GetDefaultOptions(configEntry, requiresRestart)) { }
         public IntInputFieldConfigItem(ConfigEntry<int> configEntry, IntInputFieldOptions options) : base(configEntry, options)
         {
-            MinValue = options.Min;
-            MaxValue = options.Max;
+            var acceptableValues = configEntry.Description.AcceptableValues;
+
+            MinValue = options.Min ?? (acceptableValues as AcceptableValueRange<int>)?.MinValue ?? int.MinValue;
+            MaxValue = options.Max ?? (acceptableValues as AcceptableValueRange<int>)?.MaxValue ?? int.MaxValue;
         }
 
         internal override GameObject CreateGameObjectForConfig()

--- a/Assets/Scripts/ConfigItems/IntSliderConfigItem.cs
+++ b/Assets/Scripts/ConfigItems/IntSliderConfigItem.cs
@@ -2,6 +2,7 @@ using BepInEx.Configuration;
 using UnityEngine;
 using LethalConfig.Utils;
 using LethalConfig.ConfigItems.Options;
+using System;
 
 namespace LethalConfig.ConfigItems
 {
@@ -14,8 +15,10 @@ namespace LethalConfig.ConfigItems
         public IntSliderConfigItem(ConfigEntry<int> configEntry, bool requiresRestart) : this(configEntry, GetDefaultOptions(configEntry, requiresRestart)) { }
         public IntSliderConfigItem(ConfigEntry<int> configEntry, IntSliderOptions options) : base(configEntry, options)
         {
-            MinValue = options.Min;
-            MaxValue = options.Max;
+            var acceptableValues = configEntry.Description.AcceptableValues;
+
+            MinValue = options.Min ?? (acceptableValues as AcceptableValueRange<int>)?.MinValue ?? 0;
+            MaxValue = options.Max ?? (acceptableValues as AcceptableValueRange<int>)?.MaxValue ?? 100;
         }
 
         internal override GameObject CreateGameObjectForConfig()

--- a/Assets/Scripts/ConfigItems/Options/BaseOptions.cs
+++ b/Assets/Scripts/ConfigItems/Options/BaseOptions.cs
@@ -3,6 +3,11 @@ namespace LethalConfig.ConfigItems.Options
 {
     public class BaseOptions
     {
+        public static BaseOptions Default { get; } = new()
+        {
+            RequiresRestart = true
+        };
+
         /// <summary>
         /// Overrides the name of the item displayed in the UI.
         /// Visual change only.

--- a/Assets/Scripts/ConfigItems/Options/FloatInputFieldOptions.cs
+++ b/Assets/Scripts/ConfigItems/Options/FloatInputFieldOptions.cs
@@ -3,7 +3,7 @@ namespace LethalConfig.ConfigItems.Options
 {
     public sealed class FloatInputFieldOptions: BaseOptions
     {
-        public float Min { get; set; } = float.MinValue;
-        public float Max { get; set; } = float.MaxValue;
+        public float? Min { get; set; } = null;
+        public float? Max { get; set; } = null;
     }
 }

--- a/Assets/Scripts/ConfigItems/Options/FloatSliderOptions.cs
+++ b/Assets/Scripts/ConfigItems/Options/FloatSliderOptions.cs
@@ -3,7 +3,7 @@ namespace LethalConfig.ConfigItems.Options
 {
     public class FloatSliderOptions: BaseOptions
     {
-        public float Min { get; set; } = 0.0f;
-        public float Max { get; set; } = 1.0f;
+        public float? Min { get; set; } = null;
+        public float? Max { get; set; } = null;
     }
 }

--- a/Assets/Scripts/ConfigItems/Options/IntInputFieldOptions.cs
+++ b/Assets/Scripts/ConfigItems/Options/IntInputFieldOptions.cs
@@ -3,7 +3,7 @@ namespace LethalConfig.ConfigItems.Options
 {
     public sealed class IntInputFieldOptions: BaseOptions
     {
-        public int Min { get; set; } = int.MinValue;
-        public int Max { get; set; } = int.MaxValue;
+        public int? Min { get; set; } = null;
+        public int? Max { get; set; } = null;
     }
 }

--- a/Assets/Scripts/ConfigItems/Options/IntSliderOptions.cs
+++ b/Assets/Scripts/ConfigItems/Options/IntSliderOptions.cs
@@ -3,7 +3,7 @@ namespace LethalConfig.ConfigItems.Options
 {
     public sealed class IntSliderOptions: BaseOptions
     {
-        public int Min { get; set; } = 0;
-        public int Max { get; set; } = 100;
+        public int? Min { get; set; } = null;
+        public int? Max { get; set; } = null;
     }
 }


### PR DESCRIPTION
When Min and/or Max values are not set in the options objects for sliders and inputs, attempt to read from `AcceptableValueRange` if one is present in the `ConfigEntry`. Use default values otherwise.

Fix for #15 