### PR TITLE
Forces ConfigMenu to be the last sibling whenever its opened

### DIFF
--- a/Assets/Scripts/MonoBehaviours/ConfigMenu.cs
+++ b/Assets/Scripts/MonoBehaviours/ConfigMenu.cs
@@ -23,6 +23,7 @@ namespace LethalConfig.MonoBehaviours
 
             gameObject.SetActive(true);
             menuAnimator.SetTrigger("Open");
+            transform.SetAsLastSibling();
         }
 
         public void Close(bool animated = true)


### PR DESCRIPTION
Fixes issue found with LethalProgression, where some mods could potentially be executed after LethalConfig and add stuff to the quick menu on top of LethalConfig.