### PR TITLE
Fixed menu being stuck sometimes after closing lethalconfig

### DIFF
--- a/Assets/Animations/ConfigMenu/ConfigMenu.controller
+++ b/Assets/Animations/ConfigMenu/ConfigMenu.controller
@@ -73,19 +73,19 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Close
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: ForceClose
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Animations/ConfigMenu/ConfigMenuAppear.anim
+++ b/Assets/Animations/ConfigMenu/ConfigMenuAppear.anim
@@ -118,7 +118,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Animations/ConfigMenu/ConfigMenuClosed.anim
+++ b/Assets/Animations/ConfigMenu/ConfigMenuClosed.anim
@@ -91,7 +91,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0
@@ -189,4 +189,11 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events: []
+  m_Events:
+  - time: 0
+    functionName: OnCloseAnimationEnd
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Animations/ConfigMenu/ConfigMenuDisappear.anim
+++ b/Assets/Animations/ConfigMenu/ConfigMenuDisappear.anim
@@ -118,7 +118,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0
@@ -279,11 +279,4 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events:
-  - time: 0.083333336
-    functionName: OnCloseAnimationEnd
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
+  m_Events: []

--- a/Assets/Animations/ConfigMenu/ConfigMenuNormal.anim
+++ b/Assets/Animations/ConfigMenu/ConfigMenuNormal.anim
@@ -28,15 +28,6 @@ AnimationClip:
         weightedMode: 0
         inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
         outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-      - serializedVersion: 3
-        time: 1
-        value: {x: 1, y: 1, z: 1}
-        inSlope: {x: 0, y: 0, z: 0}
-        outSlope: {x: 0, y: 0, z: 0}
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
-        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
@@ -48,15 +39,6 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 1
         value: 1
         inSlope: 0
         outSlope: 0
@@ -104,12 +86,12 @@ AnimationClip:
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1
+    m_StopTime: 0
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0
@@ -126,15 +108,6 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 1
         value: 1
         inSlope: 0
         outSlope: 0
@@ -163,15 +136,6 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0.33333334
         outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 1
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
@@ -193,15 +157,6 @@ AnimationClip:
         weightedMode: 0
         inWeight: 0.33333334
         outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 1
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 4
@@ -216,15 +171,6 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 136
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      - serializedVersion: 3
-        time: 1
         value: 1
         inSlope: 0
         outSlope: 0

--- a/Assets/Animations/ConfigMenuNotification/NotificationClosed.anim
+++ b/Assets/Animations/ConfigMenuNotification/NotificationClosed.anim
@@ -189,4 +189,11 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events: []
+  m_Events:
+  - time: 0
+    functionName: OnCloseAnimationEnd
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Animations/ConfigMenuNotification/NotificationDisappear.anim
+++ b/Assets/Animations/ConfigMenuNotification/NotificationDisappear.anim
@@ -279,11 +279,4 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events:
-  - time: 0.083333336
-    functionName: OnCloseAnimationEnd
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
+  m_Events: []

--- a/Assets/Scripts/MonoBehaviours/ConfigMenu.cs
+++ b/Assets/Scripts/MonoBehaviours/ConfigMenu.cs
@@ -40,8 +40,8 @@ namespace LethalConfig.MonoBehaviours
 
             if (!animated)
             {
-                menuAnimator.SetTrigger("ForceClose");
                 gameObject.SetActive(false);
+                menuAnimator.SetTrigger("ForceClose");
                 return;
             }
 

--- a/Assets/Scripts/MonoBehaviours/ConfigMenuNotification.cs
+++ b/Assets/Scripts/MonoBehaviours/ConfigMenuNotification.cs
@@ -19,16 +19,22 @@ namespace LethalConfig.MonoBehaviours
 
         public void Open()
         {
+            var animatorState = notificationAnimator.GetCurrentAnimatorStateInfo(0);
+            if (animatorState.IsName("NotificationNormal") || animatorState.IsName("NotificationAppear")) return;
+
             gameObject.SetActive(true);
             notificationAnimator.SetTrigger("Open");
         }
 
         public void Close(bool animated = true)
         {
+            var animatorState = notificationAnimator.GetCurrentAnimatorStateInfo(0);
+            if (animatorState.IsName("NotificationClosed") || animatorState.IsName("NotificationDisappear")) return;
+
             if (!animated)
             {
-                notificationAnimator.SetTrigger("ForceClose");
                 gameObject.SetActive(false);
+                notificationAnimator.SetTrigger("ForceClose");
                 return;
             }
 


### PR DESCRIPTION
Fixes a somewhat uncommon issue where sometimes closing the LethalConfig menu could make the player to be unable to use the mainmenu/quickmenu. Caused by the panel not being actually deactivated, blocking the ui raycast.