### PR TITLE
Forcing menu notification to be the last sibling when opened

### DIFF
--- a/Assets/Scripts/MonoBehaviours/ConfigMenuNotification.cs
+++ b/Assets/Scripts/MonoBehaviours/ConfigMenuNotification.cs
@@ -24,6 +24,7 @@ namespace LethalConfig.MonoBehaviours
 
             gameObject.SetActive(true);
             notificationAnimator.SetTrigger("Open");
+            transform.SetAsLastSibling();
         }
 
         public void Close(bool animated = true)


### PR DESCRIPTION
Same fix as with the menu, but for the notification UI.